### PR TITLE
Feat(Tracker): Configurable Fast Delete

### DIFF
--- a/ItemTracked.js
+++ b/ItemTracked.js
@@ -15,6 +15,15 @@ var computeVelocityVector = require('./utils').computeVelocityVector
 // Use a simple incremental unique id for the display
 var idDisplay = 0;
 
+// Default Params
+const params = {
+  // Remove new objects fast if they could not be matched in the next frames.
+  // Setting this to false ensures the object will stick around at least
+  // DEFAULT_UNMATCHEDFRAMES_TOLERANCE frames, even if they could neven be
+  // matched in subsequent frames.
+  fastDelete: true
+}
+
 exports.ItemTracked = function(properties, frameNb, DEFAULT_UNMATCHEDFRAMES_TOLERANCE){
   var DEFAULT_UNMATCHEDFRAMES_TOLERANCE = DEFAULT_UNMATCHEDFRAMES_TOLERANCE;
   var itemTracked = {};
@@ -111,7 +120,7 @@ exports.ItemTracked = function(properties, frameNb, DEFAULT_UNMATCHEDFRAMES_TOLE
     this.frameUnmatchedLeftBeforeDying--;
     this.isZombie = true;
     // If it was matched less than 1 time, it should die quick
-    if(this.nbTimeMatched <= 1) {
+    if(params.fastDelete && this.nbTimeMatched <= 1) {
       this.frameUnmatchedLeftBeforeDying = -1;
     }
   }
@@ -214,4 +223,10 @@ exports.ItemTracked = function(properties, frameNb, DEFAULT_UNMATCHEDFRAMES_TOLE
 
 exports.reset = function() {
   idDisplay = 0;
+}
+
+exports.setParams = function(newParams) {
+  if("fastDelete" in newParams) {
+    params.fastDelete = newParams.fastDelete;
+  }
 }

--- a/spec/Tracker.spec.js
+++ b/spec/Tracker.spec.js
@@ -11,6 +11,7 @@ const detections = [
       name: 'object'
     }
   ],
+  [], // This empty frame ensure that the object will be removed if fastDelete is enabled.
   [
     {
       x: 0.686925,
@@ -44,15 +45,43 @@ const detections = [
 ];
 
 describe('Tracker', function () {
+  beforeEach(function () {
+    Tracker.reset();
+    Tracker.setParams({
+      items: {
+        fastDelete: true
+      },
+      unMatchedFramesTolerance: 5,
+      iouLimit: 0.05
+    });
+
+    detections.forEach((frame, frameNb) => {
+      Tracker.updateTrackedItemsWithNewFrame(frame, frameNb);
+    });
+  });
+
   describe('reset', function () {
     it('resets ItemTracker idDisplay', function () {
-      detections.forEach((frame, frameNb) => {
-        Tracker.updateTrackedItemsWithNewFrame(frame, frameNb);
-      });
-
       Tracker.reset();
 
       Tracker.updateTrackedItemsWithNewFrame(detections[0], 0);
+
+      expect(Tracker.getJSONOfTrackedItems()[0].id).toBe(0);
+    });
+  });
+
+  describe('fast delete', function () {
+    it('removes items with fast delete', function () {
+      expect(Tracker.getJSONOfTrackedItems()[0].id).toBeGreaterThan(0);
+    });
+
+    it('keeps the item if fastDelete is disabled', function () {
+      Tracker.setParams({ items: { fastDelete: false } });
+      Tracker.reset();
+
+      detections.forEach((frame, frameNb) => {
+        Tracker.updateTrackedItemsWithNewFrame(frame, frameNb);
+      });
 
       expect(Tracker.getJSONOfTrackedItems()[0].id).toBe(0);
     });

--- a/tracker.js
+++ b/tracker.js
@@ -235,6 +235,11 @@ exports.setParams = function(params) {
   if(params.iouLimit) {
     IOU_LIMIT = params.iouLimit;
   }
+
+  // To keep the API simple, we just move the params down to the ItemsTracked as well.
+  if("items" in params) {
+    itemTrackedModule.setParams(params.items);
+  }
 }
 
 exports.enableKeepInMemory = function() {


### PR DESCRIPTION
This allows to configure if detections should be removed
quickly in cases where they were detected and could not
be matched afterwards.

Fast deletion can be enabled/disabled via

```js
Tracker.setParams({ items: { fastDelete: false } });
```